### PR TITLE
deployment: add ansible playbook for reverse proxy server

### DIFF
--- a/ansible-deployment/README.md
+++ b/ansible-deployment/README.md
@@ -1,0 +1,19 @@
+pre:
+* get a ubuntu:latest instance
+* install redis && libvips
+* make redis run in daemonized mode
+* install gem
+
+cmd:
+* sudo ansible-playbook site.yaml
+* sudo systemctl restart apache2
+* sudo a2enmod rewrite && sudo service apache2 restart
+
+post:
+* you now configured an apache2 server that we'll use a reverse proxy
+* ./bin/rails server
+
+
+refs:
+* https://github.com/jacobemery/linux1-ansible-lab/tree/general
+* rails docs

--- a/ansible-deployment/default-config-000.conf
+++ b/ansible-deployment/default-config-000.conf
@@ -1,0 +1,32 @@
+<VirtualHost *:80>
+        # The ServerName directive sets the request scheme, hostname and port that
+        # the server uses to identify itself. This is used when creating
+        # redirection URLs. In the context of virtual hosts, the ServerName
+        # specifies what hostname must appear in the request's Host: header to
+        # match this virtual host. For the default virtual host (this file) this
+        # value is not decisive as it is used as a last resort host regardless.
+        # However, you must set it for any further virtual host explicitly.
+        #ServerName www.example.com
+        ServerAdmin webmaster@localhost
+        DocumentRoot /var/www/html
+
+        # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+        # error, crit, alert, emerg.
+        # It is also possible to configure the loglevel for particular
+        # modules, e.g.
+        #LogLevel info ssl:warn
+
+        RewriteEngine on
+        RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC]
+        RewriteCond %{HTTP:CONNECTION} Upgrade$ [NC]
+        RewriteRule .* ws://localhost:3000%{REQUEST_URI} [P]
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        # For most configuration files from conf-available/, which are
+        # enabled or disabled at a global level, it is possible to
+        # include a line for only one particular virtual host. For example the
+        # following line enables the CGI configuration for this host only
+        # after it has been globally disabled with "a2disconf".
+        #Include mods-available/proxy.conf
+</VirtualHost>

--- a/ansible-deployment/proxy.conf
+++ b/ansible-deployment/proxy.conf
@@ -1,0 +1,28 @@
+<IfModule mod_proxy.c>
+
+        # If you want to use apache2 as a forward proxy, uncomment the
+        # 'ProxyRequests On' line and the <Proxy *> block below.
+        # WARNING: Be careful to restrict access inside the <Proxy *> block.
+        # Open proxy servers are dangerous both to your network and to the
+        # Internet at large.
+        #
+        # If you only want to use apache2 as a reverse proxy/gateway in
+        # front of some web application server, you DON'T need
+        # 'ProxyRequests On'.
+
+        #ProxyRequests On
+        #<Proxy *>
+        #   AddDefaultCharset off
+        #   Require all denied
+        #   #Require local
+        #</Proxy>
+        ProxyPreserveHost On
+        ProxyPass "/" "http://127.0.0.1:3000/"
+        ProxyPassReverse "/" "http://127.0.0.1:3000/"
+
+        # Enable/disable the handling of HTTP/1.1 "Via:" headers.
+        # ("Full" adds the server version; "Block" removes all outgoing Via: headers)
+        # Set to one of: Off | On | Full | Block
+        #ProxyVia Off
+
+</IfModule>

--- a/ansible-deployment/site.yaml
+++ b/ansible-deployment/site.yaml
@@ -1,0 +1,48 @@
+- hosts: localhost
+  tasks:
+    - name: Install required packages.
+      tags: pkgs
+      ansible.builtin.package:
+        name:
+          - apache2
+          - firewalld
+        state: present
+
+    - name: Start services.
+      tags: services
+      ansible.builtin.service:
+        name: "{{ item }}"
+        state: started
+        enabled: yes
+      loop:
+        - apache2
+        - firewalld
+
+    - name: Check to see if there is already an index.html file.
+      tags: index
+      ansible.builtin.stat:
+        path: /var/www/html/index.html
+      register: index
+
+    - name: Create custom index page, if one is not already there.
+      tags: index
+      ansible.builtin.copy:
+        src: files/index.html
+        dest: /var/www/html/index.html
+      when: index.stat.exists == False
+
+    - name: Allow http (80/tcp) traffic through the firewall.
+      tags: firewall
+      ansible.posix.firewalld:
+        service: http
+        state: enabled
+        permanent: true
+        immediate: true
+
+    - name: Allow https (443/tcp) traffic through the firewall.
+      tags: firewall
+      ansible.posix.firewalld:
+        service: https
+        state: enabled
+        permanent: true
+        immediate: true


### PR DESCRIPTION
This PR
* adds an ansible playbook to setup apache2 server on a ubuntu 22.04 LTS VM.
* sets the installed apache server as a reverse proxy for the rails app.
* contains tested configs for the deployment setup.

Tesed by deploying on a single VM
[LinuxONE Community Cloud](https://linuxone.cloud.marist.edu/)